### PR TITLE
Gh862 obsolete uid generation fix

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -27,6 +27,7 @@
 * Added Modality LUT Sequence and VOI LUT Sequence functionality when generating a DICOM Image.
 * Bug Fix: Logging requests with very long private tags throws exception (#846)
 * Bug Fix: turn off validation when creating CFind-, CGet- or CMove-Requests, since there are no newly generated data included, but already existing UIDs have to be added there. (#860, #842)
+* Bug Fix: generation of DicomUID using obsolete method Generate("name") resulted in invalid UIDs. (#862)
 
 #### v.4.0.1 (3/13/2019)
 * change IFileReference and IByteBuffer to have offset of type long so that big files can be processed (#743)

--- a/Contributors.md
+++ b/Contributors.md
@@ -48,3 +48,4 @@
 * [PalminX](https://github.com/PalminX)
 * [Pieter-Jan Van Robays](https://github.com/PieterJanVR)
 * [Alexander Moerman](https://github.com/amoerie)
+* [Harald Köstinger](https://github.com/hkoestin)

--- a/DICOM/DicomUID.cs
+++ b/DICOM/DicomUID.cs
@@ -62,55 +62,23 @@ namespace Dicom
 
     public sealed partial class DicomUID : DicomParseable
     {
-        public static string RootUID { get; set; }
-
-        private string _uid;
-
-        private string _name;
-
-        private DicomUidType _type;
-
-        private bool _retired;
+        public static string RootUID { get; set; } = "1.2.826.0.1.3680043.2.1343.1";
 
         public DicomUID(string uid, string name, DicomUidType type, bool retired = false)
         {
-            _uid = uid;
-            _name = name;
-            _type = type;
-            _retired = retired;
+            UID = uid;
+            Name = name;
+            Type = type;
+            IsRetired = retired;
         }
 
-        public string UID
-        {
-            get
-            {
-                return _uid;
-            }
-        }
+        public string UID { get; private set; }
 
-        public string Name
-        {
-            get
-            {
-                return _name;
-            }
-        }
+        public string Name { get; private set; }
 
-        public DicomUidType Type
-        {
-            get
-            {
-                return _type;
-            }
-        }
+        public DicomUidType Type { get; private set; }
 
-        public bool IsRetired
-        {
-            get
-            {
-                return _retired;
-            }
-        }
+        public bool IsRetired { get; private set; }
 
         public static void Register(DicomUID uid)
         {
@@ -125,12 +93,8 @@ namespace Dicom
         [Obsolete("This method may return statistically non-unique UIDs and is deprecated, use the method Generate()")]
         public static DicomUID Generate(string name)
         {
-            if (string.IsNullOrEmpty(RootUID))
-            {
-                RootUID = "1.2.826.0.1.3680043.2.1343.1";
-            }
-
-            var uid = $"{RootUID}.{DateTime.UtcNow}.{DateTime.UtcNow.Ticks}";
+            var now = DateTime.UtcNow;
+            var uid = $"{RootUID}.{now.ToString("yyyyMMddHHmmss")}.{now.Ticks}";
 
             return new DicomUID(uid, name, DicomUidType.SOPInstance);
         }

--- a/Tests/Desktop/DicomUIDTest.cs
+++ b/Tests/Desktop/DicomUIDTest.cs
@@ -47,6 +47,19 @@ namespace Dicom
             Assert.True(uid.UID.Length <= 64); // Currently not checked by DicomUID.IsValid
         }
 
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("TEST1")]
+        [InlineData("fo-dicom")]
+        public void Obsolete_Generate_ReturnsValidUid(string name)
+        {
+            var uid = DicomUID.Generate(name);
+
+            Assert.True(DicomUID.IsValid(uid.UID));
+            Assert.True(uid.UID.Length <= 64); // Currently not checked by DicomUID.IsValid
+        }
+
         [Fact]
         public void Generate_ReturnsDifferentUidsEachTime()
         {


### PR DESCRIPTION
Fixes #862

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [x] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- obsolete DicomUID.Generate("name") method generated invalid UIDs.