### PR TITLE
Disabling dataset validation for file meta information objects

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -28,6 +28,7 @@
 * Bug Fix: Logging requests with very long private tags throws exception (#846)
 * Bug Fix: turn off validation when creating CFind-, CGet- or CMove-Requests, since there are no newly generated data included, but already existing UIDs have to be added there. (#860, #842)
 * Bug Fix: generation of DicomUID using obsolete method Generate("name") resulted in invalid UIDs. (#862)
+* Bug Fix: Disabling dataset validation for file meta information objects. (#859)
 
 #### v.4.0.1 (3/13/2019)
 * change IFileReference and IByteBuffer to have offset of type long so that big files can be processed (#743)

--- a/DICOM/DicomFileMetaInformation.cs
+++ b/DICOM/DicomFileMetaInformation.cs
@@ -17,6 +17,9 @@ namespace Dicom
         /// </summary>
         public DicomFileMetaInformation()
         {
+            // per default, we do turn off validation as most of the use cases are
+            // creation of the meta-info from files or streams etc.
+            ValidateItems = false;
         }
 
         /// <summary>
@@ -27,6 +30,7 @@ namespace Dicom
         /// </param>
         public DicomFileMetaInformation(DicomDataset dataset)
         {
+            ValidateItems = dataset.ValidateItems;
             Version = new byte[] { 0x00, 0x01 };
 
             MediaStorageSOPClassUID = dataset.GetSingleValue<DicomUID>(DicomTag.SOPClassUID);
@@ -64,6 +68,7 @@ namespace Dicom
         /// <param name="metaInfo">DICOM file meta information to be updated.</param>
         public DicomFileMetaInformation(DicomFileMetaInformation metaInfo)
         {
+            ValidateItems = metaInfo.ValidateItems;
             Version = new byte[] { 0x00, 0x01 };
 
             if (metaInfo.Contains(DicomTag.MediaStorageSOPClassUID)) MediaStorageSOPClassUID = metaInfo.MediaStorageSOPClassUID;

--- a/Tests/Desktop/Bugs/GH859.cs
+++ b/Tests/Desktop/Bugs/GH859.cs
@@ -1,0 +1,79 @@
+﻿// Copyright (c) 2012-2019 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+
+
+using Dicom.Helpers;
+using Dicom.Network;
+
+using System.Threading;
+using System.Threading.Tasks;
+
+using Xunit;
+using Xunit.Abstractions;
+
+using DicomClient = Dicom.Network.Client.DicomClient;
+
+namespace Dicom.Bugs
+{
+    public class GH859
+    {
+        private readonly XUnitDicomLogger _output;
+
+        public GH859(ITestOutputHelper output)
+        {
+            _output = new XUnitDicomLogger(output)
+                .IncludeTimestamps()
+                .IncludeThreadId()
+                .IncludePrefix("GH859");
+        }
+
+        [Fact]
+        public async Task DicomService_reading_messages_with_invalid_UIDs_does_not_fail()
+        {
+            int port = Ports.GetNext();
+            var clientLogger = _output.IncludePrefix(nameof(Network.DicomClient));
+            var serverLogger = _output.IncludePrefix(nameof(DicomCEchoProvider));
+            var source = new CancellationTokenSource();
+
+            using (var server = DicomServer.Create<SimpleCStoreProvider>(port,
+                logger: serverLogger,
+                options: new DicomServiceOptions
+                {
+                    LogDataPDUs = true,
+                    LogDimseDatasets = true
+                }))
+            {
+                while (!server.IsListening)
+                    await Task.Delay(50);
+
+                var client = new DicomClient("127.0.0.1", port, false, "SCU", "ANY-SCP");
+                client.Logger = clientLogger;
+
+                var command = new DicomDataset();
+                command.ValidateItems = false;
+                command.Add(DicomTag.CommandField, (ushort)DicomCommandField.CStoreRequest);
+                command.Add(DicomTag.MessageID, (ushort)1);
+                command.Add(DicomTag.AffectedSOPClassUID, DicomUID.CTImageStorage);
+                command.Add(new DicomUniqueIdentifier(DicomTag.AffectedSOPInstanceUID, "1.2.3.04"));
+
+                var request = new DicomCStoreRequest(command);
+                request.File = new DicomFile();
+                request.Dataset = new DicomDataset();
+                request.Dataset.ValidateItems = false;
+                request.Dataset.Add(DicomTag.SOPClassUID, DicomUID.CTImageStorage);
+                request.Dataset.Add(new DicomUniqueIdentifier(DicomTag.SOPInstanceUID, "1.2.3.04"));
+
+                request.OnResponseReceived += (e, args) =>
+                {
+                    _output.Info("Response received. Cancelling in 500ms.");
+                    source.CancelAfter(100);
+                };
+
+                client.AddRequest(request);
+
+                await client.SendAsync(source.Token);
+            }
+        }
+    }
+}

--- a/Tests/Desktop/DICOM.Tests.Desktop.csproj
+++ b/Tests/Desktop/DICOM.Tests.Desktop.csproj
@@ -120,6 +120,7 @@
     <Compile Include="Bugs\GH626.cs" />
     <Compile Include="Bugs\GH745.cs" />
     <Compile Include="Bugs\GH846.cs" />
+    <Compile Include="Bugs\GH859.cs" />
     <Compile Include="Bugs\VideoCStoreProvider.cs" />
     <Compile Include="DicomAnonymizerTest.cs" />
     <Compile Include="DicomDatasetExtensionsTest.cs" />

--- a/Tests/Desktop/Network/SimpleCStoreProvider.cs
+++ b/Tests/Desktop/Network/SimpleCStoreProvider.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright (c) 2012-2019 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
+using Dicom.Log;
+
 using System;
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
-
-using Dicom.Log;
 
 namespace Dicom.Network
 {
@@ -73,6 +73,11 @@ namespace Dicom.Network
         {
             var tempName = Path.GetTempFileName();
             Logger.Info(tempName);
+
+            // as the incoming file could be not-valid
+            request.File.Dataset.ValidateItems = false;
+            request.File.FileMetaInfo.ValidateItems = false;
+
             request.File.Save(tempName);
 
             return new DicomCStoreResponse(request, DicomStatus.Success)


### PR DESCRIPTION
Fixes # 

#### Checklist
- [ ] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [ ] I have included unit tests
- [ ] I have updated the change log
- [ ] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- Disabling dataset validation for file meta information objects.
